### PR TITLE
Add missing source map comment when debug is true

### DIFF
--- a/src/builder/javascript.js
+++ b/src/builder/javascript.js
@@ -23,6 +23,7 @@ export default function configure(pkg, opts) {
           let output = { files: { [`${name}.js`]: result.code } }
 
           if (opts.debug) {
+            output.files[`${name}.js`] += `\n//# sourceMappingURL=${name}.js.map`
             output.files[`${name}.js.map`] = JSON.stringify(result.map)
           }
 


### PR DESCRIPTION
Without this comment, source maps won't resolve properly.
