### PR TITLE
Only use the last fragment of the package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.4.1-scoped-package-26.0",
+  "version": "0.4.1",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.4.0",
+  "version": "0.4.1-scoped-package-26.0",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/src/builder/javascript.js
+++ b/src/builder/javascript.js
@@ -1,6 +1,5 @@
 import { transformFile } from 'babel-core'
 import { default as deferred } from 'thenify'
-import { debug } from '../util/stdio'
 import { default as compat } from 'babel-plugin-add-module-exports'
 import { default as es2015 } from 'babel-preset-es2015'
 import { default as umd } from 'babel-plugin-transform-es2015-modules-umd'

--- a/src/main.js
+++ b/src/main.js
@@ -17,15 +17,19 @@ import './util/cli'
 const keys = Object.keys
 const all = Promise.all.bind(Promise)
 
-main()
+try {
+  main()
+} catch(e) {
+  console.error('error')
+  console.error(e)
+}
 
 async function main() {
   const pkgFile = resolvePkg(module, process.cwd())
       , pkgRoot = dirname(pkgFile)
 
-  var pkg = await readPkg(pkgFile)
+  let pkg = await readPkg(pkgFile)
 
-  pkg.name = (pkg.name || 'unknown').split('/').pop()
   pkg.root = pkgRoot
   pkg.resolve = (path) => relative(process.cwd(), resolve(pkgRoot, path))
   pkg.relative = (path) => relative(pkgRoot, resolve(pkgRoot, path))
@@ -46,7 +50,7 @@ async function main() {
     ]
 
   const defaults =
-    { out: pkg.relative(`${pkg.name}-min`)
+    { out: pkg.relative(`${pkg.name.split('/').pop()}-min`)
     , lib: pkg.relative(pkg.directories.lib || 'lib')
     , src: pkg.relative(pkg.directories.src || 'src')
     , optimize: 0
@@ -149,15 +153,15 @@ async function main() {
     ))
 
     if (build.result.css.length) {
-      console.debug(`Writing ${pkg.name}-min.css`)
-      let filename = pkg.resolve(`${pkg.name}-min.css`)
+      console.debug(`Writing ${opts.out}.css`)
+      let filename = pkg.resolve(`${opts.out}.css`)
       let contents = await csso(pkg, opts)(build.result.css)
       await put(filename, contents)
     }
 
     if (build.result.js.length) {
-      console.debug(`Writing ${pkg.name}-min.js`)
-      let filename = pkg.resolve(`${pkg.name}-min.js`)
+      console.debug(`Writing ${opts.out}.js`)
+      let filename = pkg.resolve(`${opts.out}.js`)
       let contents = await jso(pkg, opts)(build.result.js)
       await put(filename, contents)
     }

--- a/src/main.js
+++ b/src/main.js
@@ -17,12 +17,7 @@ import './util/cli'
 const keys = Object.keys
 const all = Promise.all.bind(Promise)
 
-try {
-  main()
-} catch(e) {
-  console.error('error')
-  console.error(e)
-}
+main()
 
 async function main() {
   const pkgFile = resolvePkg(module, process.cwd())

--- a/src/main.js
+++ b/src/main.js
@@ -25,13 +25,14 @@ async function main() {
 
   var pkg = await readPkg(pkgFile)
 
+  pkg.name = (pkg.name || 'unknown').split('/').pop()
   pkg.root = pkgRoot
   pkg.resolve = (path) => relative(process.cwd(), resolve(pkgRoot, path))
   pkg.relative = (path) => relative(pkgRoot, resolve(pkgRoot, path))
 
   pkg.directories || (pkg.directories = {})
 
-  let alwaysExclude = 
+  let alwaysExclude =
     [ `node_modules`
     , `package.json`
     , `.*`
@@ -99,7 +100,7 @@ async function main() {
 
   console.debug('Options:')
   keys(defaults).forEach(name => console.debug(`- ${name}: ${JSON.stringify(opts[name])}`))
-  
+
   const build = await timed(
     keys(pipeline).reduce(
       async (result, type) => {


### PR DESCRIPTION
## Description
Only use the last fragment of the package name

## Motivation and Context
Solves #26 

## How Was This Tested?
See #4;
also
```sh
mkdir temp && cd temp && npm init -y --scope=@zambezi && \
mkdir src && touch src/index.js && ez-build --production && \
ls temp-min.js
```
```cmd
temp-min.js
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

