### PR TITLE
Enabled the `--no-copy` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.4.2-no-copy-19.0",
+  "version": "0.4.2",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.4.1",
+  "version": "0.4.2-no-copy-19.0",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/src/main.js
+++ b/src/main.js
@@ -80,8 +80,11 @@ async function main() {
   const pipeline =
     { js: createPipeline(pkg, opts, jsc(pkg, opts))
     , css: createPipeline(pkg, opts, cssc(pkg, opts))
-    , 'copy-files': createPipeline(pkg, opts, copyFiles(pkg, opts))
     }
+
+  if (opts.copy) {
+    pipeline['copy-files'] = createPipeline(pkg, opts, copyFiles(pkg, opts))
+  }
 
   opts.include = conclude(keys(pipeline), defaults.include, opts.include)
   opts.exclude = conclude(keys(pipeline), defaults.exclude, opts.exclude)


### PR DESCRIPTION
## Description
The `--no-copy` was not working #19 . This change fixes the issue by only adding `copy-files` to the pipeline if it is enabled.

## Motivation and Context
Solves #19 .

## How Was This Tested?
```sh
mkdir -p ./temp/src && cd temp && \
touch src/index.html && touch src/index.js && \
npm init -y > /dev/null && \ 
ez-build --production --no-copy && \
ls lib/index.*
```
```
js – src/index.js -> lib\index.js,lib\index.js.map
lib/index.js  lib/index.js.map
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

