### PR TITLE
Add option to read build options from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ ez-build --help
     --interactive                  watch for and recompile on changes (implies -O 0)
     --production                   enable production options (implies -O 1)
     --flags <flags>                toggle build flags
+    @<path>                        read options from the file at <path> (relative to cwd)
 ```
 
 ## Using ez-build in npm scripts
@@ -46,8 +47,8 @@ $ ez-build --help
 A typical scripts section of a package.json when using ez-build looks something like this:
 
 ```json
-{ "dev": "ez-build --interactive"
-, "build": "ez-build --production"
+{ "build": "ez-build --production"
+, "build:dev": "ez-build --interactive"
 }
 ```
 
@@ -136,6 +137,36 @@ The available flags are:
   - `modules:<umd|amd|commonjs|systemjs|ecmascript>` allows you to control the output module format. Setting this value to `ecmascript` will disable the transformation of output module format altogether, keeping `import` and `export` statements largely intact. This flag defaults to `umd`.
   - `add-module-exports` toggles whether the UMD output of ez-build should be backwards compatible with AMD and CJS module formats. If this flag is specified, ez-build will ensure any module with a single `export default` will not export an object with a `default` key. This flag is disabled by default. It is only recommended you use this flag if you *must* keep backwards compatibility with legacy code.
   - `es2017` toggles support for compiling code ES2017 code. When ES2017 is ratified this flag will be removed and the ES2017 preset will be added by default. This flag is diabled by default.
+
+### `@<path>`
+
+Reads ez-build options from the file at `<path>`, resolved from the current working directory. This can be used to share configuration among different builds. For instance, a common scenario is to share the same build configuration between `--production` and `--interactive` builds in npm scripts, like so:
+
+```json
+{
+  "build": "ez-build --production --include \"js:**/*.js,js:**/*.jsx\" --flags es2017",
+  "build:dev": "ez-build --interactive --include \"js:**/*.js,js:**/*.jsx\" --flags es2017"
+}
+```
+
+To avoid this repetition, and also make things a bit neater, we can place this configuration in a file. The name and extension of the file doesn't matter, just pick something useful to your project. In this example, we'll use the name `build.opts`, and the contents look like this:
+
+```
+--include js:**/*.js
+--include js:**/*.jsx
+--flags es2017"
+```
+
+*(Note how we repeate the `--include` option – any option that allows a list of values be be specified multiple times like this. It can make options much more readable, and also make it easy to maintain. No longer want to include jsx files? Just remove the line.)*
+
+Now we can change our scripts to include the options from the file, making them less repetitive, and making it easier to maintain our configuration:
+
+```json
+{
+  "build": "ez-build --production @build.opts",
+  "build:dev": "ez-build --interactive @build.opts"
+}
+```
 
 ## Using additional plugins
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.0-opts-file.1",
+  "version": "0.5.0",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.0-opts-file.0",
+  "version": "0.5.0-opts-file.1",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.4.5",
+  "version": "0.4.6-opts-file.0",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.4.6-opts-file.0",
+  "version": "0.5.0-opts-file.0",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/src/util/cli.js
+++ b/src/util/cli.js
@@ -14,11 +14,12 @@ process.on('rejectionHandled', (p) => {
 })
 
 process.on('exit', code => {
+  const log = resolve('./ez-build-debug.log')
+
   if (bugs.size) {
     sysio.error(`\n---\n\nYou've found a bug! :o(\n`)
     sysio.error(`Please include the following file with any support request:\n`)
 
-    const log = resolve('./ez-build-debug.log')
     sysio.error(`  ${log}\n\n---`)
 
     let reasons = []

--- a/test/cli/opts-file.bats
+++ b/test/cli/opts-file.bats
@@ -35,3 +35,9 @@ teardown() {
   assert_equal 0 "${status}"
   assert_contains "--flags es2017 --flags add-module-exports --flags modules:amd" "${output}"
 }
+
+@test "should fail if trying to read a non-existant file" {
+  ez-build @does-not-exist
+  assert_equal 1 "${status}"
+  assert_equal "ENOENT: no such file or directory, open 'does-not-exist'" "${output}"
+}

--- a/test/cli/opts-file.bats
+++ b/test/cli/opts-file.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load test-util
+
+setup() {
+  load_fixture bare-project
+}
+
+teardown() {
+  rm *.opts
+  unload_fixture bare-project
+}
+
+@test "should read options from file when provided" {
+  echo "--flags es2017" > build.opts
+  DEBUG=1 ez-build @build.opts
+  assert_equal 0 "${status}"
+  assert_contains "--flags es2017" "${output}"
+}
+
+@test "should read options even if separated by newlines" {
+  echo "--flags es2017" > build.opts
+  echo "--flags add-module-exports" >> build.opts
+  DEBUG=1 ez-build @build.opts
+  assert_equal 0 "${status}"
+  assert_contains "--flags es2017 --flags add-module-exports" "${output}"
+}
+
+@test "should read options from nested files" {
+  echo "--flags es2017 @b.opts" > a.opts
+  echo "--flags add-module-exports @c.opts" > b.opts
+  echo "--flags modules:amd" > c.opts
+
+  DEBUG=1 ez-build @a.opts
+  assert_equal 0 "${status}"
+  assert_contains "--flags es2017 --flags add-module-exports --flags modules:amd" "${output}"
+}

--- a/test/cli/test-util.bash
+++ b/test/cli/test-util.bash
@@ -6,7 +6,7 @@ bin="${project_dirname}/bin/ez-build.js"
 ez-build() {
   echo "argc: ${bin}"
   echo "argv: ${@}"
-  ${bin} ${@}
+  run ${bin} ${@}
 }
 
 assert_equal() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Apologies for the somewhat ironic PR title. This change allows users to specify options in a file, which then gets read whenever ez-build is invoked and pointed to that file. There is no magic to how these files are found and loaded – it's entirely explicit. Whenever ez-build encounters a CLI option that starts with `@`, it will assume the rest of the string is a path to a file (relative to the current working dir) and load it under the assumption that the data within are more options. Files can include `@` references themselves, to nest the loading of options. This means there can be any number of options files, making this a pretty flexible feature.

## Motivation and Context
It came about when thinking about #27, and specifically when I wrote [this comment](https://github.com/zambezi/ez-build/issues/27#issuecomment-247125657). We've had a mounting problem of having to be increasingly wordy in our npm scripts, and as we invoke ez-build in different contexts with slightly different options, it is clear we need some way of re-using this configuration. I believe this is a good solution for that.

## How Was This Tested?
- [x] Test added to read options a single file
- [x] Test added to read options nested files
- [x] Test added to read options even when separated by newline

These tests were added in [opts-file.bats](https://github.com/zambezi/ez-build/blob/opts-file/test/cli/opts-file.bats).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed