### PR TITLE
Fix bracket glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Unoptimized files, source maps, and other generated content will be written to t
 
 Sets a pattern to describe which files to include in the build process. By default, the patterns `js:**/*.js,css:**/*.css` are specified. The patterns can be defined for different pipelines (`js:` or `css:`.) If no namespace is specified – e.g. `*.txt` – it will be added to all pipelines. Generally, you would always specify a namespace for `--include` to avoid pipelines working on incompatible files. (E.g. if you try `--include "**/*.js"` without namespace, the css compiler will also try to compile js files, which is probably not what you want.)
 
+**Note:** It's important to properly quote the pattern, to avoid the shell expanding the pattern before executing ez-build.
+
 The namespace must be added to all patterns, so to define multiple patterns either repeat the `--include` option or use comma to separate the patterns. The following are equivalent:
 
 ```bash
@@ -92,6 +94,12 @@ $ ez-build --include "js:**/*.js" --include "js:**/*.jsx"
 
 ```bash
 $ ez-build --include "js:**/*.js,js:**/*.jsx"
+```
+
+It's also possible to use braced patterns, instead of multiple comma separated patterns, which can make some configurations neater. For instance, the above pattern could be rewritten as such:
+
+```bash
+$ ez-build --include "js:**/*.{js,jsx}"
 ```
 
 Typically, this flag is only used if you have also configured additional presets or plugins.
@@ -144,8 +152,8 @@ Reads ez-build options from the file at `<path>`, resolved from the current work
 
 ```json
 {
-  "build": "ez-build --production --include \"js:**/*.js,js:**/*.jsx\" --flags es2017",
-  "build:dev": "ez-build --interactive --include \"js:**/*.js,js:**/*.jsx\" --flags es2017"
+  "build": "ez-build --production --include \"js:**/*.{js,jsx}\" --flags es2017",
+  "build:dev": "ez-build --interactive --include \"js:**/*.{js,jsx}\" --flags es2017"
 }
 ```
 
@@ -193,7 +201,7 @@ With the advent of technologies such as React, it is not uncommon to want to ext
 - Finally, depending on the presets you use, conventions may dictate you use different file extension to denote the use of non-standard language features. This is very common with JSX, and in order for ez-build to pick those files up, they must be included with the build:
 
   ```bash
-  $ ez-build --include "js:**/*.js,js:**/*.jsx"
+  $ ez-build --include "js:**/*.{js,jsx}"
   ```
 
   Note that we add the `js:**/*.js` pattern in addition to `js:**/*.jsx`, since using this option overwrites the defaults. Also note the use of namespaces in the patterns, to determine which pipeline the pattern should affect.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.2-fix-bracket-glob-patterns.1",
+  "version": "0.5.2",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.2-fix-bracket-glob-patterns.0",
+  "version": "0.5.2-fix-bracket-glob-patterns.1",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.1",
+  "version": "0.5.2-fix-bracket-glob-patterns.0",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/src/cli/opts.js
+++ b/src/cli/opts.js
@@ -36,15 +36,15 @@ export default async function parse(pkg, argv) {
     .option('-i, --src <dir>', `the root directory from which all sources are relative [${defaults.src}]`, pkg.relative, defaults.src)
     .option('-o, --out <prefix>', `write optimized output to files with the specified prefix [${defaults.out}]`, pkg.relative, defaults.out)
     .option('-L, --lib <dir>', `write unoptimized files to the specified directory [${defaults.lib}]`, pkg.relative, defaults.lib)
-    .option('-I, --include [js|css:]<path>', `include a path or glob (relative to source root) [${defaults.include}]`, concat, [])
-    .option('-X, --exclude [js|css:]<path>', `exclude a path or glob (relative to source root) [${defaults.exclude}]`, concat, [])
+    .option('-I, --include [js|css:]<path>', `include a path or glob (relative to source root) [${defaults.include}]`, concatGlobs, [])
+    .option('-X, --exclude [js|css:]<path>', `exclude a path or glob (relative to source root) [${defaults.exclude}]`, concatGlobs, [])
     .option('-O, --optimize <level>', `optimization level (0 = none) [${defaults.optimize}]`, setOptimization, defaults.optimize)
     .option('--no-copy', `disable copying of non-code files to ${defaults.lib}`, Boolean, !defaults.copy)
     .option('--no-debug', 'disable source map generation', Boolean, !defaults.debug)
     .option('--log <normal|json>', `log output format [${defaults.log}]`, /^(json|normal)$/i, defaults.log)
     .option('--interactive', `watch for and recompile on changes (implies -O 0)`)
     .option('--production', `enable production options (implies -O 1)`)
-    .option('--flags <flags>', `toggle flags [${defaults.flags}]`, concat, [])
+    .option('--flags <flags>', `toggle flags [${defaults.flags}]`, concatFlags, [])
     .option('@<path>', 'read options from the file at <path> (relative to cwd)')
 
   const opts = cli.parse(await explode(argv))
@@ -127,7 +127,12 @@ function setOptimization(level) {
   return Math.max(level | 0, 0)
 }
 
-function concat(val, list) {
+function concatGlobs(val, list) {
+  let prep = val.replace(/,([^,:]+:)/g, "\0$1")
+  return list.concat(prep.split('\0'))
+}
+
+function concatFlags(val, list) {
   return list.concat(val.split(','))
 }
 

--- a/test/unit/cli/opts.test.js
+++ b/test/unit/cli/opts.test.js
@@ -3,7 +3,7 @@ import { is } from 'funkis'
 import { loadUnit, readFixture } from '../test-util.js'
 
 test('Options', async t => {
-  t.plan(100)
+  t.plan(106)
 
   const barePkg = await readFixture('bare-project')
       , typicalPkg = await readFixture('typical-project')
@@ -85,6 +85,37 @@ test('Options', async t => {
       Object.keys(specifiedFlags).forEach(flag => {
         let value = opts.flags[flag]
         t.equal(value, specifiedFlags[flag], `${flag} set to ${specifiedFlags[flag]}`)
+      })
+    })
+  )
+
+  t.comment('Options > --include/--exclude patterns')
+  await Promise.all(
+    [ [ 'js:**/*.{js,jsx}'
+      , { js: [ '**/*.{js,jsx}' ]
+        }
+      ]
+    , [ 'js:**/*.{js,jsx},css:*.css'
+      , { js: [ '**/*.{js,jsx}' ]
+        , css: [ '*.css']
+        }
+      ]
+    , [ 'js:**/*.{js,jsx},js:*.wibble'
+      , { js: [ '**/*.{js,jsx}', '*.wibble' ]
+        }
+      ]
+    , [ 'js:**/*.{js,jsx},js:*.wibble,css:*.css'
+      , { js: [ '**/*.{js,jsx}', '*.wibble' ]
+        , css: [ '*.css']
+        }
+      ]
+    ].map(async ([pattern, expected]) => {
+      opts = await parseOpts(barePkg, argv('--include', pattern))
+
+      t.comment(`--include ${pattern}`)
+
+      Object.keys(expected).forEach(result => {
+        t.deepEqual(opts.include[result], expected[result], `${result} should equal ${expected[result]}`)
       })
     })
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As reported in #39, braced glob patterns don't work with ez-build, since it splits the patterns on `,` characters. This PR fixes that, so braced patterns work as well as others.

## Motivation and Context

The ability to use braced glob patterns make some configuration much neater, with the canonical example being that which @DimitarChristoff [mentioned in a comment](https://github.com/zambezi/ez-build/pull/37#discussion_r79352079) to #37:

```bash
ez-build --include "js:**/*.{js,jsx}"
```

Compared to way [described in the readme](https://github.com/zambezi/ez-build/blob/02ca14c88eb22d5ee691e9e3c1a612b0bff50ad9/README.md#using-additional-plugins):

```bash
ez-build --include "js:**/*.js,js:**/*.jsx"
```

## How Was This Tested?

- [x] The opts parser unit tests were expanded with additional include/exclude pattern tests ([source](https://github.com/zambezi/ez-build/blob/0916a6c1ba0af27b5ab5b14fcd944fb64f42ec35/test/unit/cli/opts.test.js#L92-L121))

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed