### PR TITLE
Set NODE_ENV if unset at runtime – or – if set, use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ This flag is ignored entirely if combined with `--production`.
 
 Runs ez-build in production mode, which implies a higher optimization level (currently `-O 1`,) as well as the generation of additional artefacts, such as a module manifest. For builds destined for deployment into Zambezi environments, this flag must be used or the builds will not work outside of debug mode.
 
+If `NODE_ENV` is not set when ez-build is invoked in production mode, it will be set to `production`. Conversely, if `NODE_ENV=production` when ez-build is invoked, it will also enable production mode in ez-build. This means there are three different ways one can enable ez-build production mode:
+
+- `ez-build --production`
+- `NODE_ENV=production ez-build`
+- `npm run --production build` (assuming `build` is a script which invokes ez-build; substitute for whatever script name you may be using)
+
 ### `--flags <flags>`
 
 Toggles flags that may affect the output or behavior of ez-build. Multiple flags can be toggled at once, just separate them with a comma. For example, `--flags es2017,modules:commonjs` would enable the `es2017` flag, and set the `modules` flag value to `commonjs`.

--- a/README.md
+++ b/README.md
@@ -132,15 +132,19 @@ Runs ez-build in interactive mode, meaning it will run continuously and watch fo
 
 This flag is ignored entirely if combined with `--production`.
 
+If `NODE_ENV=production` is set when invoking ez-build with `--interactive`, it will still enter interactive mode, but will *not* change the value of `NODE_ENV`.
+
 ### `--production`
 
 Runs ez-build in production mode, which implies a higher optimization level (currently `-O 1`,) as well as the generation of additional artefacts, such as a module manifest. For builds destined for deployment into Zambezi environments, this flag must be used or the builds will not work outside of debug mode.
 
-If `NODE_ENV` is not set when ez-build is invoked in production mode, it will be set to `production`. Conversely, if `NODE_ENV=production` when ez-build is invoked, it will also enable production mode in ez-build. This means there are three different ways one can enable ez-build production mode:
+If `NODE_ENV` is not set when ez-build is invoked in production mode, it will be set to `production`. Conversely if `NODE_ENV=production` when ez-build is invoked and no other mode is specified, e.g. `--interactive`, it will also enable production mode. This means there are three different ways one can enable ez-build production mode:
 
 - `ez-build --production`
 - `NODE_ENV=production ez-build`
 - `npm run --production build` (assuming `build` is a script which invokes ez-build; substitute for whatever script name you may be using)
+
+*Note: the `NODE_ENV=production ez-build` syntax may not work on all systems. For compatibility across operating systems, you may want to consider using something like [cross-env](https://www.npmjs.com/package/cross-env).*
 
 ### `--flags <flags>`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.2",
+  "version": "0.5.3-set-node-env.0",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.3-set-node-env.1",
+  "version": "0.5.3-set-node-env.2",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.3-set-node-env.0",
+  "version": "0.5.3-set-node-env.1",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.3-set-node-env.3",
+  "version": "0.5.3-set-node-env.4",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.3-set-node-env.2",
+  "version": "0.5.3-set-node-env.3",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.5.3-set-node-env.4",
+  "version": "0.5.3",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "^6.5.0",

--- a/src/cli/opts.js
+++ b/src/cli/opts.js
@@ -67,7 +67,7 @@ export default async function parse(pkg, argv) {
     : opts.interactive? 0
     : opts.optimize
 
-  opts.interactive = opts.production? false : opts.interactive 
+  opts.interactive = opts.production? false : opts.interactive
 
   return opts
 }

--- a/src/cli/opts.js
+++ b/src/cli/opts.js
@@ -62,6 +62,10 @@ export default async function parse(pkg, argv) {
   opts.include['copy-files'] = ['**/*']
   opts.exclude['copy-files'] = [...opts.include.js, ...opts.include.css, ...opts.exclude['*']]
 
+  if (process.env.NODE_ENV === 'production') {
+    opts.production = true
+  }
+
   opts.optimize
     = opts.production?  1
     : opts.interactive? 0

--- a/src/cli/opts.js
+++ b/src/cli/opts.js
@@ -62,7 +62,7 @@ export default async function parse(pkg, argv) {
   opts.include['copy-files'] = ['**/*']
   opts.exclude['copy-files'] = [...opts.include.js, ...opts.include.css, ...opts.exclude['*']]
 
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production' && !opts.interactive) {
     opts.production = true
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,10 @@ async function main() {
   console.debug('Options:')
   keys(opts).forEach(name => console.debug(`- ${name}: ${JSON.stringify(opts[name])}`))
 
+  if (process.env.NODE_ENV === undefined) {
+    process.env.NODE_ENV = opts.production? 'production' : 'development'
+  }
+
   const pipeline =
     { js: createPipeline(pkg, opts, jsc(pkg, opts))
     , css: createPipeline(pkg, opts, cssc(pkg, opts))

--- a/test/cli/node-env.bats
+++ b/test/cli/node-env.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+load test-util
+
+setup() {
+  load_fixture node-env
+}
+
+teardown() {
+  unload_fixture node-env
+}
+
+expected_production="$(cat <<PROD
+"production" === "development";
+"production" === "production";
+
+export default {};
+//# sourceMappingURL=index.js.map
+PROD
+)"
+
+expected_development="$(cat <<DEV
+"development" === "development";
+"development" === "production";
+
+export default {};
+//# sourceMappingURL=index.js.map
+DEV
+)"
+
+expected_overriden="$(cat <<OVERRIDE
+"wibble" === "development";
+"wibble" === "production";
+
+export default {};
+//# sourceMappingURL=index.js.map
+OVERRIDE
+)"
+
+opts="--flags modules:ecmascript"
+
+@test "should set NODE_ENV=production if --production is specified and NODE_ENV is unset" {
+  unset NODE_ENV
+  ez-build --production "${opts}"
+
+  assert_equal 0 "${status}"
+  assert_equal "${expected_production}" "$(cat lib/index.js)"
+}
+
+@test "should set NODE_ENV=development if --production is not specified and NODE_ENV is unset" {
+  unset NODE_ENV
+  ez-build "${opts}"
+
+  assert_equal 0 "${status}"
+  assert_equal "${expected_development}" "$(cat lib/index.js)"
+}
+
+@test "should not override previously set NODE_ENV values" {
+  NODE_ENV=wibble ez-build "${opts}"
+
+  assert_equal 0 "${status}"
+  assert_equal "${expected_development}" "$(cat lib/index.js)"
+}
+
+@test "should not override previously set NODE_ENV values, even if --production is set" {
+  NODE_ENV=wibble ez-build --production "${opts}"
+
+  assert_equal 0 "${status}"
+  assert_equal "${expected_development}" "$(cat lib/index.js)"
+}

--- a/test/cli/node-env.bats
+++ b/test/cli/node-env.bats
@@ -47,6 +47,20 @@ opts="--flags modules:ecmascript"
   assert_equal "${expected_production}" "$(cat lib/index.js)"
 }
 
+@test "should enable production mode if NODE_ENV=production, even if --production is not set" {
+  NODE_ENV=production ez-build "${opts}"
+  
+  assert_equal 0 "${status}"
+  assert_equal "${expected_production}" "$(cat lib/index.js)"
+}
+
+@test "should enable production mode if --production is used with npm" {
+  run npm run --production build
+  
+  assert_equal 0 "${status}"
+  assert_equal "${expected_production}" "$(cat lib/index.js)"
+}
+
 @test "should set NODE_ENV=development if --production is not specified and NODE_ENV is unset" {
   unset NODE_ENV
   ez-build "${opts}"

--- a/test/cli/node-env.bats
+++ b/test/cli/node-env.bats
@@ -39,7 +39,7 @@ OVERRIDE
 
 opts="--flags modules:ecmascript"
 
-@test "should set NODE_ENV=production if --production is specified and NODE_ENV is unset" {
+@test "'ez-build --production' should set NODE_ENV=production" {
   unset NODE_ENV
   ez-build --production "${opts}"
 
@@ -47,21 +47,21 @@ opts="--flags modules:ecmascript"
   assert_equal "${expected_production}" "$(cat lib/index.js)"
 }
 
-@test "should enable production mode if NODE_ENV=production, even if --production is not set" {
+@test "'NODE_ENV=production ez-build' should enable production mode" {
   NODE_ENV=production ez-build "${opts}"
   
   assert_equal 0 "${status}"
   assert_equal "${expected_production}" "$(cat lib/index.js)"
 }
 
-@test "should enable production mode if --production is used with npm" {
+@test "'npm run --production build' should enable production mode" {
   run npm run --production build
   
   assert_equal 0 "${status}"
   assert_equal "${expected_production}" "$(cat lib/index.js)"
 }
 
-@test "should set NODE_ENV=development if --production is not specified and NODE_ENV is unset" {
+@test "'ez-build' should set NODE_ENV=development" {
   unset NODE_ENV
   ez-build "${opts}"
 
@@ -69,14 +69,14 @@ opts="--flags modules:ecmascript"
   assert_equal "${expected_development}" "$(cat lib/index.js)"
 }
 
-@test "should not override previously set NODE_ENV values" {
+@test "'NODE_ENV=wibble ez-build' should not override NODE_ENV" {
   NODE_ENV=wibble ez-build "${opts}"
 
   assert_equal 0 "${status}"
   assert_equal "${expected_development}" "$(cat lib/index.js)"
 }
 
-@test "should not override previously set NODE_ENV values, even if --production is set" {
+@test "'NODE_ENV=wibble ez-build --production' should not override NODE_ENV" {
   NODE_ENV=wibble ez-build --production "${opts}"
 
   assert_equal 0 "${status}"

--- a/test/fixtures/node-env/.babelrc
+++ b/test/fixtures/node-env/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-inline-environment-variables"]
+}

--- a/test/fixtures/node-env/build.opts
+++ b/test/fixtures/node-env/build.opts
@@ -1,0 +1,1 @@
+--flags modules:ecmascript

--- a/test/fixtures/node-env/package.json
+++ b/test/fixtures/node-env/package.json
@@ -5,8 +5,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "scripts": {
-    "build": "ez-build --production @build.opts",
-    "build:dev": "ez-build @build.opts",
+    "build": "ez-build @build.opts",
     "clean": "rm -rf lib *-min.js *-min.css optimised-modules.json"
   },
   "author": "Marcus Stade <marcus@stade.se> (http://madebystade.se/)",

--- a/test/fixtures/node-env/package.json
+++ b/test/fixtures/node-env/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bare-project",
+  "version": "0.0.0",
+  "description": "A bare project set up",
+  "main": "lib/index.js",
+  "module": "src/index.js",
+  "scripts": {
+    "build": "ez-build --production @build.opts",
+    "build:dev": "ez-build @build.opts",
+    "clean": "rm -rf lib *-min.js *-min.css optimised-modules.json"
+  },
+  "author": "Marcus Stade <marcus@stade.se> (http://madebystade.se/)",
+  "license": "MIT",
+  "devDependencies": {
+    "babel-plugin-transform-inline-environment-variables": "6.8.0"
+  }
+}

--- a/test/fixtures/node-env/src/index.js
+++ b/test/fixtures/node-env/src/index.js
@@ -1,0 +1,4 @@
+process.env.NODE_ENV === "development"
+process.env.NODE_ENV === "production"
+
+export default {}

--- a/test/unit/cli/opts.test.js
+++ b/test/unit/cli/opts.test.js
@@ -3,7 +3,7 @@ import { is } from 'funkis'
 import { loadUnit, readFixture } from '../test-util.js'
 
 test('Options', async t => {
-  t.plan(106)
+  t.plan(114)
 
   const barePkg = await readFixture('bare-project')
       , typicalPkg = await readFixture('typical-project')
@@ -127,6 +127,29 @@ test('Options', async t => {
   t.notOk(opts.interactive, 'disables interactive mode')
   opts = await parseOpts(barePkg, argv('--production', '--interactive'))
   t.notOk(opts.interactive, 'always disables interactive mode')
+
+  t.comment('Options > NODE_ENV=production')
+  process.env.NODE_ENV='production'
+  opts = await parseOpts(barePkg, argv())
+  t.equal(opts.optimize, 1, 'implies -O 1')
+  t.ok(opts.production, 'enables production mode')
+  t.notOk(opts.interactive, 'disables interactive mode')
+  opts = await parseOpts(barePkg, argv('--interactive'))
+  t.notOk(opts.interactive, 'always disables interactive mode')
+
+  t.comment('Options > NODE_ENV=development')
+  process.env.NODE_ENV='development'
+  opts = await parseOpts(barePkg, argv())
+  t.notOk(opts.production, 'does not enable production mode')
+  opts = await parseOpts(barePkg, argv('--interactive'))
+  t.ok(opts.interactive, 'does not affect interactive mode')
+
+  t.comment('Options > NODE_ENV=interactive')
+  process.env.NODE_ENV='interactive'
+  opts = await parseOpts(barePkg, argv())
+  t.notOk(opts.production, 'does not enable production mode')
+  opts = await parseOpts(barePkg, argv('--interactive'))
+  t.ok(opts.interactive, 'does not enable interactive mode')
 
   t.comment('Options > --interactive')
   opts = await parseOpts(barePkg, argv('--interactive'))

--- a/test/unit/cli/opts.test.js
+++ b/test/unit/cli/opts.test.js
@@ -129,13 +129,14 @@ test('Options', async t => {
   t.notOk(opts.interactive, 'always disables interactive mode')
 
   t.comment('Options > NODE_ENV=production')
+  const OLD_ENV = process.env.NODE_ENV
   process.env.NODE_ENV='production'
   opts = await parseOpts(barePkg, argv())
   t.equal(opts.optimize, 1, 'implies -O 1')
   t.ok(opts.production, 'enables production mode')
   t.notOk(opts.interactive, 'disables interactive mode')
   opts = await parseOpts(barePkg, argv('--interactive'))
-  t.notOk(opts.interactive, 'always disables interactive mode')
+  t.ok(opts.interactive, 'does not disable interactive mode')
 
   t.comment('Options > NODE_ENV=development')
   process.env.NODE_ENV='development'
@@ -150,6 +151,7 @@ test('Options', async t => {
   t.notOk(opts.production, 'does not enable production mode')
   opts = await parseOpts(barePkg, argv('--interactive'))
   t.ok(opts.interactive, 'does not enable interactive mode')
+  process.env.NODE_ENV = OLD_ENV
 
   t.comment('Options > --interactive')
   opts = await parseOpts(barePkg, argv('--interactive'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When the `--production` flag is set, we ensure ez-build also sets `NODE_ENV` internally, such that build setups that use `process.env.NODE_ENV` substitutions work as expected. However, if `NODE_ENV` is already set, we leave it alone. Additionally, if `NODE_ENV` is set to `production` prior to invoking ez-build, it too will enable production mode. This means it's possible to enable production mode in the following ways:

- `ez-build --production`
- `NODE_ENV=production ez-build`
- `npm run --production build` where `build` is a script that invokes ez-build

## Motivation and Context

More color on this topic is found in #38, which is fixed by this PR.

## How Was This Tested?

Both unit tests and CLI tests were added, to test for options parsing and changes to build execution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed