### PR TITLE
added targetBrowsers to postcss options for continuity, closes #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,12 @@ Define which browsers that ez-build should do its best to target when producing 
 
 ```bash
 $ ez-build --target-browsers "last 3 versions"
+$ ez-build --target-browsers "Firefox >=44,Chrome >=48,IE >=9,last 2 version"
 ```
 
 This feature will *not* enable experimental features, even though target browsers may support them.
+
+The same array is also passed to the `postCSS` processor so it will directly impact autoprefixer.
 
 ### `--target-node [<current|number|false>]`
 

--- a/README.md
+++ b/README.md
@@ -154,12 +154,16 @@ Define which browsers that ez-build should do its best to target when producing 
 
 ```bash
 $ ez-build --target-browsers "last 3 versions"
-$ ez-build --target-browsers "Firefox >=44,Chrome >=48,IE >=9,last 2 version"
+```
+To configure multiple browsers:
+
+```sh
+$ ez-build --target-browsers "Firefox >= 44,Chrome >= 48,IE >= 9,last 2 versions"
 ```
 
 This feature will *not* enable experimental features, even though target browsers may support them.
 
-The same array is also passed to the `postCSS` processor so it will directly impact autoprefixer.
+The same query is used to determine the feature set in the JavaScript and CSS auto-prefixer output. It is currently not possible to configure these independently.
 
 ### `--target-node [<current|number|false>]`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "6.23.0",

--- a/src/builder/css.js
+++ b/src/builder/css.js
@@ -5,7 +5,7 @@ import { slurp } from '../util/file'
 import { relative } from 'path'
 
 export default function configure(pkg, opts) {
-  const cc = postcss([cssimport, cssnext({browsers: opts.targetBrowsers})])()
+  const cc = postcss([cssimport, cssnext({browsers: opts.targetBrowsers})])
       , map = opts.debug? { inline: false } : false
 
   return async function process(name, file) {

--- a/src/builder/css.js
+++ b/src/builder/css.js
@@ -5,7 +5,7 @@ import { slurp } from '../util/file'
 import { relative } from 'path'
 
 export default function configure(pkg, opts) {
-  const cc = postcss([cssimport, cssnext])
+  const cc = postcss([cssimport, cssnext({browsers: opts.targetBrowsers})])()
       , map = opts.debug? { inline: false } : false
 
   return async function process(name, file) {

--- a/test/cli/css-browser-targets.bats
+++ b/test/cli/css-browser-targets.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load test-util
+
+setup() {
+  load_fixture css-target-browsers
+}
+
+teardown() {
+  unload_fixture css-target-browsers
+}
+
+@test "should work with single, simple target" {
+  run "${EZ_BUILD_BIN}" --target-browsers "IE 9"
+
+  assert_success
+  assert_expected "$(cat lib/foo.css)"
+}
+
+@test "should work with more complex, multiple targets" {
+  run "${EZ_BUILD_BIN}" --target-browsers "Firefox <=44,Chrome <=48,IE <=9"
+
+  assert_success
+  assert_expected "$(cat lib/foo.css)"
+}

--- a/test/cli/expected/css-browser-targets--should_work_with_more_complex__multiple_targets--1
+++ b/test/cli/expected/css-browser-targets--should_work_with_more_complex__multiple_targets--1
@@ -1,0 +1,9 @@
+.foo {
+  color: blue;
+  background-color: var(--color);
+  -webkit-transform: translate(0, 100%);
+     -moz-transform: translate(0, 100%);
+      -ms-transform: translate(0, 100%);
+          transform: translate(0, 100%);
+}
+/*# sourceMappingURL=foo.css.map */

--- a/test/cli/expected/css-browser-targets--should_work_with_single__simple_target--1
+++ b/test/cli/expected/css-browser-targets--should_work_with_single__simple_target--1
@@ -1,0 +1,7 @@
+.foo {
+  color: blue;
+  background-color: var(--color);
+  -ms-transform: translate(0, 100%);
+      transform: translate(0, 100%);
+}
+/*# sourceMappingURL=foo.css.map */

--- a/test/cli/opts-file.bats
+++ b/test/cli/opts-file.bats
@@ -23,7 +23,7 @@ teardown() {
   echo "--flags es2017" > build.opts
   echo "--flags add-module-exports" >> build.opts
   DEBUG=1 ez-build @build.opts
-  
+
   assert_success
   assert_output_contains "--flags es2017 --flags add-module-exports"
 }

--- a/test/fixtures/css-target-browsers/package.json
+++ b/test/fixtures/css-target-browsers/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bare-project",
+  "version": "0.0.0",
+  "description": "A bare project set up",
+  "main": "lib/index.js",
+  "module": "src/index.js",
+  "scripts": {
+    "build": "ez-build --production",
+    "dev": "ez-build --interactive",
+    "clean": "rm -rf lib *-min.js *-min.css optimised-modules.json"
+  },
+  "author": "Marcus Stade <marcus@stade.se> (http://madebystade.se/)",
+  "license": "MIT"
+}

--- a/test/fixtures/css-target-browsers/src/foo.css
+++ b/test/fixtures/css-target-browsers/src/foo.css
@@ -1,0 +1,5 @@
+.foo {
+  color: blue;
+  background-color: var(--color);
+  transform: translate(0, 100%);
+}

--- a/test/fixtures/css-target-browsers/src/index.js
+++ b/test/fixtures/css-target-browsers/src/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/test/fixtures/typical-project/package.json
+++ b/test/fixtures/typical-project/package.json
@@ -8,7 +8,7 @@
     "lib": "./lib"
   },
   "scripts": {
-    "build": "ez-build --production --target-browsers \"Firefox >=44,Chrome >=48,IE >=9,last 2 version\"",
+    "build": "ez-build --production",
     "dev": "ez-build --interactive",
     "clean": "rm -rf lib *-min.js *-min.css optimised-modules.json"
   },

--- a/test/fixtures/typical-project/package.json
+++ b/test/fixtures/typical-project/package.json
@@ -8,7 +8,7 @@
     "lib": "./lib"
   },
   "scripts": {
-    "build": "ez-build --production",
+    "build": "ez-build --production --target-browsers \"Firefox >=44,Chrome >=48,IE >=9,last 2 version\"",
     "dev": "ez-build --interactive",
     "clean": "rm -rf lib *-min.js *-min.css optimised-modules.json"
   },

--- a/test/fixtures/typical-project/src/foo.css
+++ b/test/fixtures/typical-project/src/foo.css
@@ -1,4 +1,5 @@
 .foo {
   color: blue;
   background-color: var(--color);
+  transform: translate(0, 100%);
 }

--- a/test/fixtures/typical-project/src/foo.css
+++ b/test/fixtures/typical-project/src/foo.css
@@ -1,5 +1,4 @@
 .foo {
   color: blue;
   background-color: var(--color);
-  transform: translate(0, 100%);
 }


### PR DESCRIPTION
> # DISCLAIMER
> I would prefer to see a separate option `--target-browsers-css` as you may have different goals but anyway. 

## Description

See #51 

## How Was This Tested?

It honours the setting and exports / preserves -ms specific CSS properties when required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that _could_ cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes 

Keep in mind the cli tests do not run on windows and break, they also spawn 100s of bash*32 processes due to BAT being unable to resolve folders. Test case was added in `test/fixtures/typical-project` to include a transform in CSS that requires IE9 support and is set accordingly in `package.json` build, expected result should have `-ms-transform` as well as `transform` props.
