### PR TITLE
update relative paths URLs using postcss-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "6.23.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "postcss": "^5.2.14",
     "postcss-cssnext": "^2.9.0",
     "postcss-import": "^9.1.0",
-    "postcss-url": "^5.1.2",
+    "postcss-url": "^6.3.1",
     "read-package-json": "2.0.4",
     "source-map-support": "0.4.11",
     "strip-ansi": "3.0.1",

--- a/test/cli/postcss.bats
+++ b/test/cli/postcss.bats
@@ -11,7 +11,7 @@ teardown() {
 }
 
 @test "should update relative path URLs in CSS" {
-  ez-build --production @build.opts
+  ez-build --production
 
   assert_contains "url(local-image.png)" "$(cat lib/common.css)"
   assert_contains "url(lib/local-image.png)" "$(cat typical-project-min.css)"
@@ -22,28 +22,28 @@ teardown() {
 }
 
 @test "should not update absolute path URLs in CSS" {
-  ez-build --production @build.opts
+  ez-build --production
 
   assert_contains "url(/absolute-image.png)" "$(cat lib/common.css)"
   assert_contains "url(/absolute-image.png)" "$(cat typical-project-min.css)"
 }
 
 @test "should not update share path URLs in CSS" {
-  ez-build --production @build.opts
+  ez-build --production
 
   assert_contains "url(//foo/share-image.png)" "$(cat lib/common.css)"
   assert_contains "url(//foo/share-image.png)" "$(cat typical-project-min.css)"
 }
 
 @test "should not update external path URLs in CSS" {
-  ez-build --production @build.opts
+  ez-build --production
 
   assert_contains "url(http://www.google.com/external-image.png)" "$(cat lib/common.css)"
   assert_contains "url(http://www.google.com/external-image.png)" "$(cat typical-project-min.css)"
 }
 
 @test "should not update \"data:\" path URLs in CSS" {
-  ez-build --production @build.opts
+  ez-build --production
 
   assert_contains "url(data:image/png;base64,iVBO==)" "$(cat lib/common.css)"
   assert_contains "url(data:image/png;base64,iVBO==)" "$(cat typical-project-min.css)"

--- a/test/cli/postcss.bats
+++ b/test/cli/postcss.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load test-util
+
+setup() {
+  load_fixture typical-project
+}
+
+teardown() {
+  unload_fixture typical-project
+}
+
+@test "should update relative path URLs in CSS" {
+  ez-build
+
+  assert_contains "url(local-image.png)" "$(cat lib/common.css)"
+  assert_contains "url(lib/local-image.png)" "$(cat typical-project-min.css)"
+
+  assert_contains "url(deep-image.png)" "$(cat lib/deep/bar.css)"
+  assert_contains "url(deep/deep-image.png)" "$(cat lib/common.css)"
+  assert_contains "url(lib/deep/deep-image.png)" "$(cat typical-project-min.css)"
+}
+
+@test "should not update absolute path URLs in CSS" {
+  ez-build
+
+  assert_contains "url(/absolute-image.png)" "$(cat lib/common.css)"
+  assert_contains "url(/absolute-image.png)" "$(cat typical-project-min.css)"
+}
+
+@test "should not update share path URLs in CSS" {
+  ez-build
+
+  assert_contains "url(//foo/share-image.png)" "$(cat lib/common.css)"
+  assert_contains "url(//foo/share-image.png)" "$(cat typical-project-min.css)"
+}
+
+@test "should not update external path URLs in CSS" {
+  ez-build
+
+  assert_contains "url(http://www.google.com/external-image.png)" "$(cat lib/common.css)"
+  assert_contains "url(http://www.google.com/external-image.png)" "$(cat typical-project-min.css)"
+}
+
+@test "should not update \"data:\" path URLs in CSS" {
+  ez-build
+
+  assert_contains "url(data:image/png;base64,iVBO==)" "$(cat lib/common.css)"
+  assert_contains "url(data:image/png;base64,iVBO==)" "$(cat typical-project-min.css)"
+}

--- a/test/cli/postcss.bats
+++ b/test/cli/postcss.bats
@@ -11,7 +11,7 @@ teardown() {
 }
 
 @test "should update relative path URLs in CSS" {
-  ez-build
+  ez-build --production @build.opts
 
   assert_contains "url(local-image.png)" "$(cat lib/common.css)"
   assert_contains "url(lib/local-image.png)" "$(cat typical-project-min.css)"
@@ -22,28 +22,28 @@ teardown() {
 }
 
 @test "should not update absolute path URLs in CSS" {
-  ez-build
+  ez-build --production @build.opts
 
   assert_contains "url(/absolute-image.png)" "$(cat lib/common.css)"
   assert_contains "url(/absolute-image.png)" "$(cat typical-project-min.css)"
 }
 
 @test "should not update share path URLs in CSS" {
-  ez-build
+  ez-build --production @build.opts
 
   assert_contains "url(//foo/share-image.png)" "$(cat lib/common.css)"
   assert_contains "url(//foo/share-image.png)" "$(cat typical-project-min.css)"
 }
 
 @test "should not update external path URLs in CSS" {
-  ez-build
+  ez-build --production @build.opts
 
   assert_contains "url(http://www.google.com/external-image.png)" "$(cat lib/common.css)"
   assert_contains "url(http://www.google.com/external-image.png)" "$(cat typical-project-min.css)"
 }
 
 @test "should not update \"data:\" path URLs in CSS" {
-  ez-build
+  ez-build --production @build.opts
 
   assert_contains "url(data:image/png;base64,iVBO==)" "$(cat lib/common.css)"
   assert_contains "url(data:image/png;base64,iVBO==)" "$(cat typical-project-min.css)"

--- a/test/fixtures/typical-project/src/b.js
+++ b/test/fixtures/typical-project/src/b.js
@@ -5,5 +5,4 @@ if (true) {
   console.log('lulz')
 }
 
-export all from foo
 export default 'b'

--- a/test/fixtures/typical-project/src/common.css
+++ b/test/fixtures/typical-project/src/common.css
@@ -8,5 +8,5 @@
   background-image: url(/absolute-image.png);
   background-image: url(//foo/share-image.png);
   background-image: url(http://www.google.com/external-image.png);
-  background-image: url(data:font/woff;charset=utf-8;base64,d09GRgABAAA==);
+  background-image: url(data:image/png;base64,iVBO==);
 }

--- a/test/fixtures/typical-project/src/common.css
+++ b/test/fixtures/typical-project/src/common.css
@@ -5,7 +5,8 @@
   --color: pink;
   background-color: var(--color);
   background-image: url(local-image.png);
-  background-image: url(/local-image.png);
-  background-image: url(//foo/local-image.png);
-  background-image: url(http://www.google.com/local-image.png);
+  background-image: url(/absolute-image.png);
+  background-image: url(//foo/share-image.png);
+  background-image: url(http://www.google.com/external-image.png);
+  background-image: url(data:font/woff;charset=utf-8;base64,d09GRgABAAA==);
 }

--- a/test/fixtures/typical-project/src/deep/bar.css
+++ b/test/fixtures/typical-project/src/deep/bar.css
@@ -1,3 +1,4 @@
 .bar {
   color: pink;
+  background: url(deep-image.png);
 }


### PR DESCRIPTION


The issue is due to the import of stylesheets not getting their URL paths rebased, which causes issues when referencing from CSS in a different directory.  

**src/styles/icons.css**
```css
@import "./icons/icon-pack-24.css";
@import "./icons/icon-pack-32.css";
/* ... */
```

**src/styles/icons/icon-pack-24.css**
```css
.icon-badge-24 {
    background-image: url("../../assets/icons/badge-24px.png");
}
/* ... */
```

Image icon is at path `<project-root>/src/assets/icons/badge-24px.png` and when build with ez-build it gets coppied to `<project-root>/lib/assets/icons/badge-24px.png` 


## Description

Added a build step so that for relative URLs, the correct relative path chosen.

## Motivation and Context

Motivations for this change are discussed in #48.

## How Was This Tested?

Tests added and manual testing on a project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
