### PR TITLE
Fix target node

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "ez-build": "bin/ez-build.js"
   },
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The Zambezi build process",
   "devDependencies": {
     "babel-cli": "6.23.0",

--- a/src/cli/opts.js
+++ b/src/cli/opts.js
@@ -49,8 +49,8 @@ export default async function parse(pkg, argv) {
     .option('--log <normal|json>', `log output format [${defaults.log}]`, /^(json|normal)$/i, defaults.log)
     .option('--interactive', `watch for and recompile on changes (implies -O 0)`)
     .option('--production', `enable production options (implies -O 1)`)
-    .option('--target-browsers <spec|false>', `define target browser environments:  [${defaults['target-browsers']}]`, concatFlags, [])
-    .option('--target-node <current|number|false>', `define target node environmet: [${defaults['target-node']}]`, defaults.targetNode)
+    .option('--target-browsers <spec|false>', `define target browser environments:  [${defaults.targetBrowsers}]`, concatFlags, [])
+    .option('--target-node <current|number|false>', `define target node environment: [${defaults.targetNode}]`, defaults.targetNode)
     .option('--flags <flags>', `toggle flags [${defaults.flags}]`, concatFlags, [])
     .option('@<path>', 'read options from the file at <path> (relative to cwd)')
 
@@ -71,6 +71,10 @@ export default async function parse(pkg, argv) {
     opts.targetBrowsers = defaults.targetBrowsers
   } else if (opts.targetBrowsers.length === 1 && opts.targetBrowsers[0] === 'false') {
     opts.targetBrowsers = false
+  }
+
+  if (opts.targetNode !== 'current') {
+    opts.targetNode = (Number(opts.targetNode) || false)
   }
 
   const rawFlags = flag(defaults.flags, opts.flags)

--- a/src/main.js
+++ b/src/main.js
@@ -32,13 +32,18 @@ async function main() {
     process.env.NODE_ENV = opts.production? 'production' : 'development'
   }
 
-  const pipeline =
-    { js: createPipeline(pkg, opts, jsc(pkg, opts))
-    , css: createPipeline(pkg, opts, cssc(pkg, opts))
-    }
+  try {
+    const pipeline =
+      { js: createPipeline(pkg, opts, jsc(pkg, opts))
+      , css: createPipeline(pkg, opts, cssc(pkg, opts))
+      }
 
-  if (opts.copy) {
-    pipeline['copy-files'] = createPipeline(pkg, opts, copyFiles(pkg, opts))
+    if (opts.copy) {
+      pipeline['copy-files'] = createPipeline(pkg, opts, copyFiles(pkg, opts))
+    }
+  } catch (e) {
+    console.error(red(`Failed to start compiler: ${e.message}`))
+    process.exit(1)
   }
 
   const build = await timed(

--- a/src/main.js
+++ b/src/main.js
@@ -32,8 +32,10 @@ async function main() {
     process.env.NODE_ENV = opts.production? 'production' : 'development'
   }
 
+  let pipeline
+
   try {
-    const pipeline =
+    pipeline =
       { js: createPipeline(pkg, opts, jsc(pkg, opts))
       , css: createPipeline(pkg, opts, cssc(pkg, opts))
       }

--- a/test/unit/cli/opts.test.js
+++ b/test/unit/cli/opts.test.js
@@ -8,7 +8,7 @@ import
   } from 'js-combinatorics'
 
 test('Options', async t => {
-  t.plan(53)
+  t.plan(57)
 
   const barePkg = await readFixture('bare-project')
       , typicalPkg = await readFixture('typical-project')
@@ -191,6 +191,16 @@ test('Options', async t => {
   t.deepEqual(opts.targetBrowsers, ['last 3 versions', 'Chrome 48'], '--target-browsers allows multiple queries')
   opts = await parseOpts(typicalPkg, argv('--target-browsers', 'false'))
   t.equal(opts.targetBrowsers, false, '--target-browsers can be disabled')
+
+  t.comment('Options > --target-node')
+  opts = await parseOpts(typicalPkg, argv('--target-node', '8'))
+  t.equal(opts.targetNode, 8, '--target-node parses numbers')
+  opts = await parseOpts(typicalPkg, argv('--target-node', 'false'))
+  t.equal(opts.targetNode, false, '--target-node can be disabled')
+  opts = await parseOpts(typicalPkg, argv('--target-node', 'current'))
+  t.equal(opts.targetNode, 'current', '--target-node can be "current"')
+  opts = await parseOpts(typicalPkg, argv('--target-node', 'bleh'))
+  t.equal(opts.targetNode, false, '--target-node with an invalid value will default it to false')
 })
 
 function generateCombinations(flags) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix parsing of the `--target-node` option.

## Motivation and Context
The --target-node option didn't correctly parse the option into a number, and because of that would crash when setting to any value other than `current`. Additionally, we'll print a more helpful error when the compiler can't be initialized.

## How Was This Tested?
Tests were added to `test/unit/cli/opts.test.js`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed